### PR TITLE
Add bashtester support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bashtester"]
+	path = bashtester
+	url = ../bashtester

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Shell Standard Library
 For an example of how to install/import see:
 
 import_install_example.sh
+
+For testing bash code across multiple versions of bash we highly recommend
+using the bashtester submodule, you can pull it with this repository by using:
+
+git clone --recurse-submodules https://github.com/sdelements/shtdlib.git
+
+Or if you've already cloned this project you can initialize and pull using:
+
+git submodule init
+git submodule update --recursive

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ For an example of how to install/import see:
 
 import_install_example.sh
 
+
 For testing bash code across multiple versions of bash we highly recommend
 using the bashtester submodule, you can pull it with this repository by using:
 
@@ -14,3 +15,28 @@ Or if you've already cloned this project you can initialize and pull using:
 
 git submodule init
 git submodule update --recursive
+
+
+Test Examples:
+
+# all supported versions
+import shtdlib.sh && test_shtdlib
+
+# local bash only, no containers
+import shtdlib.sh && test_shtdlib local
+
+# specific bash version(s)
+import shtdlib.sh && 3.1.23 4.4.23
+
+
+Supported bash versions currently include the following though not all
+functions will be supported on all versions.
+
+3.1.23
+3.2.57
+4.0.44
+4.1.17
+4.2.53
+4.3.48
+4.4.23
+5.0-beta

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import shtdlib.sh && test_shtdlib
 import shtdlib.sh && test_shtdlib local
 
 # specific bash version(s)
-import shtdlib.sh && 3.1.23 4.4.23
+import shtdlib.sh && test_shtdlib 3.1.23 4.4.23
 
 
 Supported bash versions currently include the following though not all

--- a/import_install_example.sh
+++ b/import_install_example.sh
@@ -6,16 +6,16 @@ default_install_path='/usr/local/bin'
 
 # Library download function, optionally accepts a full path/name and URL
 function download_lib {
-    tmp_path="${1:-$(mktemp)}"
-    lib_url="${2:-${default_base_download_url}/${default_library_name}}"
+    local tmp_path="${1:-$(mktemp)}"
+    local lib_url="${2:-${default_base_download_url}/${default_library_name}}"
     curl -s -l -o "${tmp_path}" "${lib_url}" || wget --no-verbose "${lib_url}" --output-document "${tmp_path}" || return 1
 }
 
 # Library install function, optionallly accepts a URL and a full path/name
 # shellcheck disable=SC2120,SC2119
 function install_lib {
-    lib_path="${1:-${default_install_path}/${default_library_name}}"
-    lib_name="${2:-$(basename "${lib_path}")}"
+    local lib_path="${1:-${default_install_path}/${default_library_name}}"
+    local lib_name="${2:-$(basename "${lib_path}")}"
     tmp_path="${3:-$(mktemp)}"
 
     echo "Installing library ${lib_name} to ${lib_path}"
@@ -30,14 +30,16 @@ function install_lib {
 # Library import function, accepts one optional parameter, name of the file to import
 # shellcheck disable=SC2120,SC2119
 function import_lib {
-    lib_name="${1:-${default_library_name}}"
-    lib_no_ext="${lib_name%.*}"
-    lib_basename_s="${lib_no_ext##*/}"
-    full_path="$(readlink -f "${BASH_SOURCE[0]}" 2> /dev/null || realpath "${BASH_SOURCE[0]}" 2> /dev/null || greadlink -f "${BASH_SOURCE[1]}" 2> /dev/null:-"${0}")"
+    local full_path
+    local lib_name="${1:-${default_library_name}}"
+    local lib_no_ext="${lib_name%.*}"
+    local lib_basename_s="${lib_no_ext##*/}"
+    full_path="$(readlink -f "${BASH_SOURCE[0]}" 2> /dev/null || realpath "${BASH_SOURCE[0]}" 2> /dev/null || greadlink -f "${BASH_SOURCE[1]}" 2> /dev/null)"
+    full_path="${full_path:-${0}}"
     # Search current dir and walk down to see if we can find the library in a
     # parent directory or sub directories of parent directories named lib/bin
     while true; do
-        pref_pattern=( "${full_path}/${lib_name}" "${full_path}/${lib_basename_s}/${lib_name}" "${full_path}/lib/${lib_name}" "${full_path}/bin/${lib_name}" )
+        local pref_pattern=( "${full_path}/${lib_name}" "${full_path}/${lib_basename_s}/${lib_name}" "${full_path}/lib/${lib_name}" "${full_path}/bin/${lib_name}" )
         for pref_lib in "${pref_pattern[@]}" ; do
             if [ -e "${pref_lib}" ] ; then
                 echo "Importing ${pref_lib}"
@@ -57,7 +59,6 @@ function import_lib {
         fi
     done
 }
-
 
 # Import the shell standard library
 # shellcheck disable=SC2119

--- a/import_install_example.sh
+++ b/import_install_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 default_library_name='shtdlib.sh'
 default_base_download_url='https://raw.githubusercontent.com/sdelements/shtdlib/master'

--- a/import_install_example.sh
+++ b/import_install_example.sh
@@ -16,7 +16,7 @@ function download_lib {
 function install_lib {
     local lib_path="${1:-${default_install_path}/${default_library_name}}"
     local lib_name="${2:-$(basename "${lib_path}")}"
-    tmp_path="${3:-$(mktemp)}"
+    local tmp_path="${3:-$(mktemp)}"
 
     echo "Installing library ${lib_name} to ${lib_path}"
     download_lib "${tmp_path}" "${default_base_download_url}/${lib_name}"

--- a/import_install_example.sh
+++ b/import_install_example.sh
@@ -34,7 +34,7 @@ function import_lib {
     local lib_name="${1:-${default_library_name}}"
     local lib_no_ext="${lib_name%.*}"
     local lib_basename_s="${lib_no_ext##*/}"
-    full_path="$(readlink -f "${BASH_SOURCE[0]}" 2> /dev/null || realpath "${BASH_SOURCE[0]}" 2> /dev/null || greadlink -f "${BASH_SOURCE[1]}" 2> /dev/null)"
+    full_path="$(readlink -f "${BASH_SOURCE[0]}" 2> /dev/null || realpath "${BASH_SOURCE[0]}" 2> /dev/null || greadlink -f "${BASH_SOURCE[0]}" 2> /dev/null)"
     full_path="${full_path:-${0}}"
     # Search current dir and walk down to see if we can find the library in a
     # parent directory or sub directories of parent directories named lib/bin

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -318,7 +318,7 @@ function test_decorator {
                                 '4.4.23' \
                                 '5.0-beta' )
         supported_bash_versions=( ${supported_bash_versions[@]:-"${default_bash_versions[@]}"} )
-        verbosity=${verbosity:-} bash_images="${supported_bash_versions[*]}" bashtester/run.sh /usr/local/bin/bash -c ". /code/${BASH_SOURCE[0]} && ${@}"
+        verbosity="${verbosity:-}" bash_images="${supported_bash_versions[*]}" bashtester/run.sh /usr/local/bin/bash -c ". /code/${BASH_SOURCE[0]} && ${*}"
         return 0
     fi
     return 1
@@ -456,7 +456,8 @@ function compare_versions {
 
     items=( ${@} )
     assert [ ${#items[@]} -gt 0 ]
-    lowest_ver=$(printf "%s\\n" "${items[@]}" | version_sort | head -n1)
+    # shellcheck disable=2119
+    lowest_ver="$(printf "%s\\n" "${items[@]}" | version_sort | head -n1)"
     for (( i=0; i<${#items[@]}; i++ )) ; do
         if [ "${items[i]}" == "${lowest_ver}" ] ; then
             debug 10 "${FUNCNAME} returning ${i}"

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -308,7 +308,7 @@ function shopt_decorator {
 # space separated string of the supported versions.
 function test_decorator {
     # If not running in a container
-    if [ "${FUNCNAME[0]}" != "${FUNCNAME[2]}" ] && ! cat /proc/1/cgroup | grep -q docker; then
+    if [ "${FUNCNAME[0]}" != "${FUNCNAME[2]}" ] && ! grep -q docker /proc/1/cgroup ; then
         default_bash_versions=( '3.1.23' \
                                 '3.2.57' \
                                 '4.0.44' \
@@ -2190,7 +2190,7 @@ function test_shtdlib {
     # Run this function inside bash containers as/if specified
     if in_array 'local' "${@}" ; then
         if [ "${#}" -ne 1 ] ; then
-            supported_bash_versions="${@/local}"
+            supported_bash_versions=( "${@/local}" )
             test_decorator "${FUNCNAME[0]}"
         fi
     else

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -319,7 +319,7 @@ function test_decorator {
                                 '5.0-beta' )
         supported_bash_versions=( ${supported_bash_versions[@]:-"${default_bash_versions[@]}"} )
 
-        bash_images="${supported_bash_versions[*]}" bashtester/run.sh /usr/local/bin/bash -c ". /code/${BASH_SOURCE[0]}" && ${@}
+        bash_images="${supported_bash_versions[*]}" bashtester/run.sh /usr/local/bin/bash -c ". /code/${BASH_SOURCE[0]} && ${@}"
         return 0
     fi
     return 1
@@ -2180,7 +2180,8 @@ function test_shopt_decorator {
 
 # Primary Unit Test Function
 function test_shtdlib {
-    test_decorator "${FUNCNAME[0]}" "${@:-}" && return || conditional_exit_on_fail 121 "Failed to run ${FUNCNAME[0]} with test_decorator"
+    test_decorator "${FUNCNAME[0]}" "${@:-}" && return
+    echo TEST
 
     color_echo green "Testing shtdlib functions"
     color_echo cyan "OS Family is: ${os_family}"


### PR DESCRIPTION
This adds a submodule/container to test on all bash versions and fixes the most basic things so that the shtdlib should import on all bash v. 3.1+ though many features won't.