### PR TITLE
Check for interactive shell before killing parent processes when on exit

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -350,7 +350,7 @@ function test_decorator {
                                 '4.4.23' \
                                 '5.0-beta' )
         supported_bash_versions=( ${supported_bash_versions[@]:-"${default_bash_versions[@]}"} )
-        verbosity="${verbosity:-}" bash_images="${supported_bash_versions[*]}" bashtester/run.sh ". /code/${BASH_SOURCE[0]} && ${*}"
+        verbosity="${verbosity:-}" bash_images="${supported_bash_versions[*]}" bashtester/run.sh ". /code/shtdlib.sh && ${*}"
         return 0
     fi
     return 1
@@ -2606,7 +2606,6 @@ function test_create_secure_tmp {
 # assumed to be container image names (bash versions) to test with.
 # Also supports "local" which will test without using containers.
 function test_shtdlib {
-    export verbosity=11
     # Run this function inside bash containers as/if specified
     if in_array 'local' "${@:-}" ; then
         if [ "${#}" -ne 1 ] ; then

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -2606,6 +2606,7 @@ function test_create_secure_tmp {
 # assumed to be container image names (bash versions) to test with.
 # Also supports "local" which will test without using containers.
 function test_shtdlib {
+    export verbosity=11
     # Run this function inside bash containers as/if specified
     if in_array 'local' "${@:-}" ; then
         if [ "${#}" -ne 1 ] ; then

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -915,7 +915,7 @@ function on_exit {
     fi
     debug 10 "Finished cleaning up, de-registering signal trap"
     trap - EXIT
-    if [ ! $interactive ]; then
+    if ! $interactive ; then
         # Be a nice Unix citizen and propagate the signal
         kill -s EXIT ${$}
     fi
@@ -935,7 +935,7 @@ function on_break {
     fi
     # Be a nice Unix citizen and propagate the signal
     trap - "${1}"
-     if [ ! $interactive ]; then
+    if ! $interactive ; then
         # Be a nice Unix citizen and propagate the signal
         kill -s EXIT ${$}
     fi

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -914,9 +914,11 @@ function on_exit {
         fi
     fi
     debug 10 "Finished cleaning up, de-registering signal trap"
-    # Be a nice Unix citizen and propagate the signal
     trap - EXIT
-    kill -s EXIT ${$}
+    if [ ! $interactive ]; then
+        # Be a nice Unix citizen and propagate the signal
+        kill -s EXIT ${$}
+    fi
 }
 
 function on_break {
@@ -933,7 +935,10 @@ function on_break {
     fi
     # Be a nice Unix citizen and propagate the signal
     trap - "${1}"
-    kill -s "${1}" "${$}"
+     if [ ! $interactive ]; then
+        # Be a nice Unix citizen and propagate the signal
+        kill -s EXIT ${$}
+    fi
 }
 
 function add_on_exit {

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -350,7 +350,7 @@ function test_decorator {
                                 '4.4.23' \
                                 '5.0-beta' )
         supported_bash_versions=( ${supported_bash_versions[@]:-"${default_bash_versions[@]}"} )
-        verbosity="${verbosity:-}" bash_images="${supported_bash_versions[*]}" bashtester/run.sh ". /code/shtdlib.sh && ${*}"
+        verbosity="${verbosity:-}" bash_images="${supported_bash_versions[*]}" bashtester/run.sh ". /code/$(basename ${BASH_SOURCE[0]}) && ${*}"
         return 0
     fi
     return 1

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -917,7 +917,7 @@ function on_exit {
     trap - EXIT
     if ! $interactive ; then
         # Be a nice Unix citizen and propagate the signal
-        kill -s EXIT ${$}
+        kill -s EXIT "${$}"
     fi
 }
 
@@ -937,7 +937,7 @@ function on_break {
     trap - "${1}"
     if ! $interactive ; then
         # Be a nice Unix citizen and propagate the signal
-        kill -s EXIT ${$}
+        kill -s "${1}" "${$}"
     fi
 }
 


### PR DESCRIPTION
When shtdlib is imported in the shell, the on_exit process will kill all parent processes on any received SIGINT signal. This can be inconvenient when running an interactive shell because the Ctrl-C command will cause the shell to be killed. 

This change stops parent processes from being killed if the shell is running in interactive mode.