### PR TITLE
Fix/test pipeline

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -356,7 +356,7 @@ function shopt_decorator {
                 debug 10 "Got return code ${return_code}"
                 # Set the option again in case it was unset
                 debug 10 "(Re)Setting ${shopt_decorator_option_name}"
-                on_break "${return_code}" "shopt -so \"${shopt_decorator_option_name}\""
+                add_on_break "${return_code}" "shopt -so \"${shopt_decorator_option_name}\""
                 return "${return_code}"
             else
                 # Option is not set

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -399,6 +399,7 @@ function shopt_decorator {
 # space separated string of the supported versions.
 function test_decorator {
     # If not running in a container
+    color_echo cyan "Executing test ${FUNCNAME[0]}..."
     if [ "${FUNCNAME[0]}" != "${FUNCNAME[2]:-}" ] && ! grep -q docker /proc/1/cgroup 2> /dev/null ; then
         default_bash_versions=( '3.1.23' \
                                 '3.2.57' \
@@ -2541,6 +2542,7 @@ alias "mantrap"='color_echo green "************,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
 # Test function to decorate
 function test_shopt_decorator {
+    color_echo cyan "Executing test ${FUNCNAME[0]}..."
     shopt_decorator_option_name='pipefail'
     shopt_decorator_option_value=true
     # shellcheck disable=2015
@@ -2552,6 +2554,8 @@ function test_shopt_decorator {
 
 # Test signaling
 function test_signal_process {
+    color_echo cyan "Executing test ${FUNCNAME[0]}..."
+
     signal_processor SIGUSR2 'exit 42' > /dev/null
     local sub_pid_0="${!}"
     signal_processor SIGUSR1 "sleep 2 && kill -s SIGUSR2 ${sub_pid_0} && exit 42" > /dev/null
@@ -2575,6 +2579,8 @@ function test_signal_process {
 
 # Test filesystem monitoring/event triggers
 function test_add_on_mod {
+    color_echo cyan "Executing test ${FUNCNAME[0]}..."
+
     if ! ( whichs inotifywait || whichs fswatch ) ; then
         debug 4 "Unable to locate inotify or fswatch, trying to install them"
         install_package inotify-tools fswatch
@@ -2612,6 +2618,8 @@ function test_add_on_mod {
 
 # Test function for create_secure_tmp function
 function test_create_secure_tmp {
+    color_echo cyan "Executing test ${FUNCNAME[0]}..."
+
     local tmp_file
     local tmp_dir
 

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -299,6 +299,47 @@ function on_break {
     fi
 }
 
+function add_on_exit {
+    debug 10 "Registering signal action on exit: \"${*}\""
+    if [ -n "${on_exit:-}" ] ; then
+        local n="${#on_exit[@]}"
+    else
+        local n=0
+    fi
+    on_exit[${n}]="${*}"
+    debug 10 "on_exit content: ${on_exit[*]}, size: ${#on_exit[*]}, keys: ${!on_exit[*]}"
+}
+
+function add_on_break {
+    debug 10 "Registering signal action on break: \"${*}\""
+    if [ -n "${on_break:-}" ] ; then
+        local n="${#on_break[@]}"
+    else
+        local n=0
+    fi
+    on_break[${n}]="${*}"
+    debug 10 "on_break content: ${on_break[*]}, size: ${#on_break[*]}, keys: ${!on_break[*]}"
+}
+
+function add_on_sig {
+    add_on_exit "${*}"
+    add_on_break "${*}"
+}
+
+function clear_sig_registry {
+    debug 10 "Clearing all registered signal actions"
+    on_exit=()
+    on_break=()
+}
+
+debug 10 "Setting up signal traps"
+trap on_exit EXIT
+trap "on_break INT" INT
+trap "on_break QUIT" QUIT
+trap "on_break TERM" TERM
+debug 10 "Signal trap successfully initialized"
+
+
 # Umask decorator, changes the umask for a function
 # To use this add a line like the following (without #) as the first line of a function
 # umask_decorator "${FUNCNAME[0]}" "${@:-}" && return
@@ -992,46 +1033,6 @@ function add_on_mod {
     done
 }
 
-
-function add_on_exit {
-    debug 10 "Registering signal action on exit: \"${*}\""
-    if [ -n "${on_exit:-}" ] ; then
-        local n="${#on_exit[@]}"
-    else
-        local n=0
-    fi
-    on_exit[${n}]="${*}"
-    debug 10 "on_exit content: ${on_exit[*]}, size: ${#on_exit[*]}, keys: ${!on_exit[*]}"
-}
-
-function add_on_break {
-    debug 10 "Registering signal action on break: \"${*}\""
-    if [ -n "${on_break:-}" ] ; then
-        local n="${#on_break[@]}"
-    else
-        local n=0
-    fi
-    on_break[${n}]="${*}"
-    debug 10 "on_break content: ${on_break[*]}, size: ${#on_break[*]}, keys: ${!on_break[*]}"
-}
-
-function add_on_sig {
-    add_on_exit "${*}"
-    add_on_break "${*}"
-}
-
-function clear_sig_registry {
-    debug 10 "Clearing all registered signal actions"
-    on_exit=()
-    on_break=()
-}
-
-debug 10 "Setting up signal traps"
-trap on_exit EXIT
-trap "on_break INT" INT
-trap "on_break QUIT" QUIT
-trap "on_break TERM" TERM
-debug 10 "Signal trap successfully initialized"
 
 # Creates a secure temporary directory or file
 #   First argument (REQUIRED) is the name of the caller's return variable


### PR DESCRIPTION
The shopt_decorator's order of operations is causing failure in the test_add_on_mod test case.

In this test, shopt_decorator is unsetting the errexit flag in order for a process to correctly terminate with custom 82 return code. However the problem occurs because just before shopt_decorator returns, it restores the errexit flag first, and then proceed to return itself with the custom return code from the decorated function. This triggers errexit when shopt_decorator returns and causes the shell to fail despite the desired behavior being setting errexit to false.

The fix implemented here involves using the add_on_break trap to reset shopt options after the decorator has itself returned.
