### PR TITLE
adding uri hostname to fqdn function

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -1914,16 +1914,21 @@ function uri_unparser {
     echo "${working_uri}"
 }
 
-## Try to find and replace the hostname of a URI with the FQDN. Remains the same if it resolves, or
-## is unable to resolve.
+## Uniform Resource Identifier (URI) Hostname to Fully Qualified Domain Name (FQDN)
+# Opportunistically resolves the hostname portion of a URI, and replaces it
+# with a FQDN using the hosts file, DNS servers, and search domains. If no match
+# is found, then uses the unresolved hostname of the original URI. Returns status
+# code 1 if URI fails to parse.
+## Example
 # $ uri_hostname_to_fqdn http://app:8080
 # http://app.example.com:8080
 function uri_hostname_to_fqdn {
     uri="${*}"
-    uri_parser ${uri}
+    uri_parser ${uri} || return 1
     new_uri_host=$(getent hosts ${uri_host} | awk '{ print $2}')
     uri_host=${new_uri_host:-${uri_host}}
-    uri_unparser
+    new_uri=$(uri_unparser)
+    echo "${new_uri}"
 }
 
 ## Strip all leading/trailing whitespaces

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -1914,6 +1914,10 @@ function uri_unparser {
     echo "${working_uri}"
 }
 
+## Try to find and replace the hostname of a URI with the FQDN. Remains the same if it resolves, or
+## is unable to resolve.
+# $ uri_hostname_to_fqdn http://app:8080
+# http://app.example.com:8080
 function uri_hostname_to_fqdn {
     uri="${*}"
     uri_parser ${uri}

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -1914,6 +1914,14 @@ function uri_unparser {
     echo "${working_uri}"
 }
 
+function uri_hostname_to_fqdn {
+    uri="${*}"
+    uri_parser ${uri}
+    new_uri_host=$(getent hosts ${uri_host} | awk '{ print $2}')
+    uri_host=${new_uri_host:-${uri_host}}
+    uri_unparser
+}
+
 ## Strip all leading/trailing whitespaces
 function strip_space {
     echo -n "${@}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -1924,12 +1924,13 @@ function uri_unparser {
 # http://app.example.com:8080
 function uri_hostname_to_fqdn {
     uri="${*}"
-    uri_parser ${uri} || return 1
+    uri_parser "${uri}" || return 1
 
-    local fqdns=$(getent hosts ${uri_host})
+    local fqdns
+    fqdns=$(getent hosts "${uri_host}")
 
     # If hostname exists in hosts library, return
-    if $(echo ${fqdns} | egrep -q "(^| )${uri_host}( |$)"); then
+    if echo "${fqdns}" | grep -E -q "(^| )${uri_host}( |$)"; then
         echo "${uri}"
         return 0
     fi
@@ -1939,9 +1940,9 @@ function uri_hostname_to_fqdn {
     local domain_names=($(grep -e "^search" /etc/resolv.conf))
     for domain_name in "${domain_names[@]:1}"; do  # first element is "search", skip
         new_uri_host="${uri_host}.${domain_name}"
-        if $(echo ${fqdns} | egrep -q "(^| )${new_uri_host}( |$)"); then
+        if echo "${fqdns}" | grep -E -q "(^| )${new_uri_host}( |$)"; then
             # Found a match, set it as the new URI host, and break out of the matrix
-            uri_host=${new_uri_host}
+            uri_host="${new_uri_host}"
             break
         fi
     done

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -1926,21 +1926,21 @@ function uri_hostname_to_fqdn {
     uri="${*}"
     uri_parser "${uri}" || return 1
 
-    local fqdns
-    fqdns=$(getent hosts "${uri_host}")
+    local fqdnames
+    fqdnames=$(getent hosts "${uri_host}")
 
     # If hostname exists in hosts library, return
-    if echo "${fqdns}" | grep -E -q "(^| )${uri_host}( |$)"; then
+    if echo "${fqdnames}" | grep -E -q "(^| )${uri_host}( |$)"; then
         echo "${uri}"
         return 0
     fi
 
     # If it doesn't exist, try appending the domains found under "search" in /etc/resolv.conf
     local new_uri_host
-    local domain_names=($(grep -e "^search" /etc/resolv.conf))
+    local domain_names=($(grep -e '^search' /etc/resolv.conf))
     for domain_name in "${domain_names[@]:1}"; do  # first element is "search", skip
         new_uri_host="${uri_host}.${domain_name}"
-        if echo "${fqdns}" | grep -E -q "(^| )${new_uri_host}( |$)"; then
+        if echo "${fqdnames}" | grep -E -q "(^| )${new_uri_host}( |$)"; then
             # Found a match, set it as the new URI host, and break out of the matrix
             uri_host="${new_uri_host}"
             break


### PR DESCRIPTION
Use case for this function is for finding the FQDN using `resolv.conf` before being used in something like NGINX that has a separate hostname resolver.