### PR TITLE
Adding additional docker virtualization platform check for Linux containers

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -143,6 +143,7 @@ fi
 
 # Store local IP addresses (not localhost), if it is not virtualized in Docker
 # shellcheck disable=SC2046
+local_ip_addresses=''
 if [ "${virt_platform}" != 'Docker' ]; then
     local_ip_addresses="$( ( (whichs ip && ip -4 addr show) || (whichs ifconfig && ifconfig) || awk '/32 host/ { print "inet " f } {f=$2}' <<< \"$(</proc/net/fib_trie)\") | grep -v 127. | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | sort -u)"
 fi

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -141,9 +141,8 @@ elif [ "${os_family}" == 'Alpine' ]; then
     os_name='alpine'
 fi
 
-# Store local IP addresses (not localhost), if it is not virtualized in Docker
+# Store local IP addresses (not localhost), if it is not virtualized using lxc or docker
 # shellcheck disable=SC2046
-local_ip_addresses=''
 if [ "${virt_platform}" != 'Docker' ]; then
     local_ip_addresses="$( ( (whichs ip && ip -4 addr show) || (whichs ifconfig && ifconfig) || awk '/32 host/ { print "inet " f } {f=$2}' <<< \"$(</proc/net/fib_trie)\") | grep -v 127. | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | sort -u)"
 fi

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -148,17 +148,21 @@ function get_local_ip_addresses {
         whichs ip && ip -4 addr show
     ) || (
         whichs ifconfig && ifconfig
-    ) || awk '/32 host/ { print "inet " f } {f=$2}' <<< \"$(</proc/net/fib_trie)\" )
-    echo "${ip_addrs}" \
-    | grep -v 127. \
-    | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
-    | grep -Eo '([0-9]*\.){3}[0-9]*' \
-    | sort -u
+    ) || (
+        awk '/32 host/ { print "inet " f } {f=$2}' <<< \"$(</proc/net/fib_trie)\"
+    ) )
+    (
+        echo "${ip_addrs}" \
+        | grep -v 127. \
+        | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
+        | grep -Eo '([0-9]*\.){3}[0-9]*' \
+        | sort -u
+    ) ||:
 }
 
 # DEPRECATED: use function `get_local_ip_addresses`
 # shellcheck disable=SC2046
-local_ip_addresses="$(get_local_ip_addresses ||:)"
+local_ip_addresses="$(get_local_ip_addresses)"
 
 # Color Constants
 export black='\e[0;30m'

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -144,20 +144,18 @@ fi
 # Gets local IP addresses (excluding localhost)
 function get_local_ip_addresses {
     local ip_addrs
-    ip_addrs=$((
-        whichs ip && ip -4 addr show
-    ) || (
-        whichs ifconfig && ifconfig
-    ) || (
-        awk '/32 host/ { print "inet " f } {f=$2}' <<< "$(</proc/net/fib_trie)"
-    ))
-    (
-        echo "${ip_addrs}" \
-        | grep -v 127. \
-        | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
-        | grep -Eo '([0-9]*\.){3}[0-9]*' \
-        | sort -u
-    ) ||:
+    ip_addrs=$(( whichs ip && ip -4 addr show ) || \
+               ( whichs ifconfig && ifconfig ) || \
+               ( awk '/32 host/ { print "inet " f } {f=$2}' <<< "$(</proc/net/fib_trie)" ))
+    ip_addrs="$( echo "${ip_addrs}" | \
+                 grep -v '127.' | \
+                 grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | \
+                 grep -Eo '([0-9]*\.){3}[0-9]*' | \
+                 sort -u )"
+    if [ -z "${ip_addrs}" ] ; then
+        return 1
+    fi
+    echo "${ip_addrs}"
 }
 
 # DEPRECATED: use function `get_local_ip_addresses`

--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -144,13 +144,13 @@ fi
 # Gets local IP addresses (excluding localhost)
 function get_local_ip_addresses {
     local ip_addrs
-    ip_addrs=$( (
+    ip_addrs=$((
         whichs ip && ip -4 addr show
     ) || (
         whichs ifconfig && ifconfig
     ) || (
-        awk '/32 host/ { print "inet " f } {f=$2}' <<< \"$(</proc/net/fib_trie)\"
-    ) )
+        awk '/32 host/ { print "inet " f } {f=$2}' <<< "$(</proc/net/fib_trie)"
+    ))
     (
         echo "${ip_addrs}" \
         | grep -v 127. \


### PR DESCRIPTION
Containers, more specifically Docker, does not necessarily have a network. Therefore when using `shtdlib.sh` in scripts, it will fail to find any IP addresses. As a result, the subsequent `grep` commands will fail and return exit code 1 without any error messages.

A method of detecting the virtualization platform already exists in `shtdlib.sh` but requires root access, the added method does not. 