### PR TITLE
get human readable name for git tags

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -2224,7 +2224,7 @@ function get_git_ref {
     assert whichs git
     cd "${1:-.}" || exit_on_fail
     git_ref="$(git rev-parse HEAD)"
-    git_tag="$(_version_sort "$(git show-ref --tags | grep "${git_ref}" || git show-ref | grep "${git_ref}" | awk -F/ '{ print $NF}')" | tail -n1)"
+    git_tag="$(_version_sort "$(awk -F/ '{ print $NF}' <(git show-ref --tags | grep "${git_ref}" || git show-ref | grep "${git_ref}"))" | tail -n1)"
     export git_ref
     export git_tag
     cd "${original_path}" || exit_on_fail


### PR DESCRIPTION
Fix bug when parsing for human readable tag in the git show-ref --tags output.
The issue occurs when working on a tagged branch. The output value is not parsed for the human readable segment and the whole string including space is returned as a result:
``aaa9f045fe929737b6227061bd22401f599c44f3 refs/tags/5.6.9qa``
expected output:
``5.6.9qa``
