### PR TITLE
Fixing running awk output as command

### DIFF
--- a/shtdlib.sh
+++ b/shtdlib.sh
@@ -158,7 +158,7 @@ function get_local_ip_addresses {
     elif whichs ifconfig ; then
         ifconfig | filter_sort_local_ip_addresses
     else
-        $(awk '/32 host/ { print "inet " f } {f=$2}' </proc/net/fib_trie) | \
+        awk '/32 host/ { print "inet " f } {f=$2}' </proc/net/fib_trie | \
             filter_sort_local_ip_addresses
     fi
 }


### PR DESCRIPTION
The changed line attempts to run the output of `awk` as a command, resulting in the the script attempting to run the command `inet`, which is undesired.

Running this inside a container
```
[root@3e48a38da6ca workspace]# source /shtdlib/shtdlib.sh
bash: inet: command not found
```